### PR TITLE
Type::Tiny 1.007_009 and above has an improved `inline_assert` that should handle MooX::TypeTiny's needs

### DIFF
--- a/lib/Method/Generate/Accessor/Role/TypeTiny.pm
+++ b/lib/Method/Generate/Accessor/Role/TypeTiny.pm
@@ -16,6 +16,19 @@ around _generate_isa_check => sub {
     ? sprintf('$args->{%s}', quotify($init_arg))
     : sprintf('$self->{%s}', quotify($name));
 
+  if (eval($check->VERSION) >= 1.007009) {
+    my $assertion = $check->inline_assert(
+      $value,
+      $var,
+      mgaca           => 0,
+      attribute_name  => $name,
+      attribute_step  => 'isa check',
+      varname         => $varname,
+    );
+    $assertion =~ s/;\z//;
+    return $assertion;
+  }
+
   my $inline_check = $check->can_be_inlined ? $check->inline_check($value)
                                             : "${var}->check(${value})";
 

--- a/t/noninline.t
+++ b/t/noninline.t
@@ -1,0 +1,52 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Fatal;
+use Type::Tiny;
+use Sub::Quote qw(quote_sub);
+use Types::Standard qw(Int Num);
+
+my $int;
+BEGIN {
+  $int = Int->where(sub{1})->plus_coercions(Num,=> sub{ int $_ });
+}
+
+BEGIN {
+  package MooClassMXTT;
+  use Moo;
+  use MooX::TypeTiny;
+
+  has attr_isa        => (is => 'rw', isa => $int );
+  has attr_coerce     => (is => 'rw', coerce => $int->coercion );
+  has attr_isa_coerce => (is => 'rw', isa => $int, coerce => $int->coercion );
+}
+
+BEGIN {
+  package MooClass;
+  use Moo;
+
+  has attr_isa        => (is => 'rw', isa => $int );
+  has attr_coerce     => (is => 'rw', coerce => $int->coercion );
+  has attr_isa_coerce => (is => 'rw', isa => $int, coerce => $int->coercion );
+}
+
+my $goto = MooClassMXTT->new;
+my $wanto = MooClass->new;
+
+for my $attr (qw(attr_isa attr_coerce attr_isa_coerce)) {
+  for my $value (1, 1.2, "welp") {
+    my $want;
+    my $want_e = exception { $want = $wanto->$attr($value) };
+    my $got;
+    my $got_e = exception { $got = $goto->$attr($value) };
+    defined and s/\(eval \d+\)//, s/ line \d+//
+      for $want_e, $got_e;
+
+    is $got_e, $want_e,
+      "inlined code has same exception as base $attr check with $value";
+    is $got, $want,
+      "inlined code has same result as base $attr check with $value";
+  }
+}
+
+done_testing;

--- a/xt/bench.t
+++ b/xt/bench.t
@@ -46,7 +46,7 @@ for my $attr (qw(attr_isa attr_coerce attr_isa_coerce)) {
 
     my $bench = Dumbbench->new(
       target_rel_precision => 0.005,
-      initial_runs         => 20,
+      initial_runs         => 200,
     );
     $bench->add_instances(
       map {


### PR DESCRIPTION
There's probably still some scope for improvement, but hopefully this is a little better.